### PR TITLE
fix: Prevent FAB from appearing below footer on short content pages

### DIFF
--- a/src/util/share/ShareFAB.tsx
+++ b/src/util/share/ShareFAB.tsx
@@ -10,6 +10,7 @@ export function ShareFAB() {
     url: string;
   } | null>(null);
   const [isConsentVisible, setIsConsentVisible] = useState(false);
+  const [footerOffset, setFooterOffset] = useState(0);
 
   useEffect(() => {
     setPageInfo({
@@ -23,29 +24,61 @@ export function ShareFAB() {
       setIsConsentVisible(!!banner);
     };
 
+    // フッターの位置を監視し、FABがフッターより下に行かないようにする
+    const updateFooterOffset = () => {
+      const footer = document.querySelector("footer");
+      if (footer) {
+        const footerRect = footer.getBoundingClientRect();
+        const windowHeight = window.innerHeight;
+        const footerTop = footerRect.top;
+        
+        // フッターが画面の下部近くにある場合、FABを調整
+        if (footerTop < windowHeight - 80) { // 80px = FABのサイズ + マージン
+          setFooterOffset(windowHeight - footerTop + 16); // 16px マージン
+        } else {
+          setFooterOffset(0);
+        }
+      }
+    };
+
     // 初期チェック
     checkConsentBanner();
+    updateFooterOffset();
 
     // MutationObserverでDOM変更を監視
-    const observer = new MutationObserver(checkConsentBanner);
+    const observer = new MutationObserver(() => {
+      checkConsentBanner();
+      updateFooterOffset();
+    });
     observer.observe(document.body, {
       childList: true,
       subtree: true,
     });
 
+    // リサイズイベントでフッター位置を再計算
+    const handleResize = () => {
+      updateFooterOffset();
+    };
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", updateFooterOffset);
+
     return () => {
       observer.disconnect();
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", updateFooterOffset);
     };
   }, []);
 
   if (!pageInfo) {
     return null;
   }
+  
   // メインコンテンツの幅に基づいて右端の位置を計算
   const getPositionClass = () => {
     // コンテンツ幅: モバイル 368px, タブレット 752px, デスクトップ 880px/960px
     // 画面中央からコンテンツ右端までの距離を計算し、そこからFABを少し内側に配置
     const baseClass = "fixed z-50";
+    
     const bottomClass = isConsentVisible
       ? "bottom-36 md:bottom-24"
       : "bottom-4";
@@ -59,6 +92,14 @@ export function ShareFAB() {
       "right-12 md:right-[calc(50vw-392px)] lg:right-[calc(50vw-516px)]";
 
     return `${baseClass} ${bottomClass} ${positionClass}`;
+  };
+
+  // フッターオフセットがある場合のインラインスタイル
+  const getInlineStyle = () => {
+    if (footerOffset > 0) {
+      return { bottom: `${footerOffset}px` };
+    }
+    return {};
   };
 
   const handleShare = async () => {
@@ -81,6 +122,7 @@ export function ShareFAB() {
     <button
       onClick={handleShare}
       className={`${getPositionClass()} flex h-12 w-12 items-center justify-center rounded-full bg-orange-600 text-white shadow-lg transition-all duration-200 hover:scale-105`}
+      style={getInlineStyle()}
       title="シェア"
     >
       <Image


### PR DESCRIPTION
## Summary
- Fixes issue #428 where the FAB (Floating Action Button) appears below the footer on pages with very short content
- Added dynamic footer position monitoring to the ShareFAB component
- FAB now automatically adjusts its position to stay above the footer when content height is small

## Changes Made
- Added `footerOffset` state to track footer position relative to viewport
- Implemented `updateFooterOffset` function that monitors footer position
- Added scroll and resize event listeners for responsive positioning
- Used inline styles for dynamic positioning to avoid Tailwind CSS compilation issues
- FAB position is recalculated when DOM changes, window resizes, or scrolling occurs

## Test Plan
- [x] Build and lint checks pass
- [ ] Test on pages with very short content to verify FAB stays above footer
- [ ] Test on normal-length pages to ensure FAB behavior remains unchanged  
- [ ] Test responsive behavior on different screen sizes
- [ ] Verify FAB positioning with/without consent banner

🤖 Generated with [Claude Code](https://claude.ai/code)