### PR TITLE
fix: WorkLinkのサムネイル表示を固定コンテナサイズで改善

### DIFF
--- a/src/util/work/components/WorkLink.tsx
+++ b/src/util/work/components/WorkLink.tsx
@@ -19,11 +19,13 @@ export const WorkLink: React.FC<WorkLinkProps> = ({
   return (
     <a href={`./${slug}`}>
       <div className="flex h-fit w-full flex-col gap-2 bg-zinc-50 p-2 md:flex-row md:gap-4">
-        <img
-          src={thumbnail.url}
-          alt={thumbnail.alt}
-          className="h-[96px] w-[128px] object-fill md:h-[144px] md:w-[192px] lg:h-[192px] lg:w-[256px]"
-        />
+        <div className="h-[96px] w-[128px] flex-shrink-0 bg-gray-100 md:h-[144px] md:w-[192px] lg:h-[192px] lg:w-[256px]">
+          <img
+            src={thumbnail.url}
+            alt={thumbnail.alt}
+            className="h-full w-full object-contain"
+          />
+        </div>
         <div>
           <h2 className="text-xl font-bold lg:text-2xl">{title}</h2>
           <p className="text-base md:text-lg lg:text-xl">ジャンル:</p>


### PR DESCRIPTION
## 概要
- WorkLinkコンポーネントで小さい画像が圧縮されてしまう問題を修正
- 元画像のサイズに関係なく、一貫したサムネイル寸法を保証

## 変更内容
- サムネイル画像を固定サイズのコンテナdivで囲む
- `flex-shrink-0`を追加してflexレイアウトでのコンテナ圧縮を防止
- 画像のobject-fitを`object-cover`から`object-contain`に変更してアスペクト比を保持
- 画像がコンテナより小さい場合の視覚的一貫性のためグレー背景を追加

## 効果
- サムネイルが一貫したレイアウトとスペーシングを維持
- 小さい画像が圧縮や歪みを受けなくなる
- 作品エントリー間での視覚的一貫性の向上
- 画像のアスペクト比を保持

🤖 Generated with [Claude Code](https://claude.ai/code)