### PR TITLE
Fix AdSense ad overflow on mobile devices

### DIFF
--- a/src/util/adsense/GoogleAdSense.tsx
+++ b/src/util/adsense/GoogleAdSense.tsx
@@ -48,6 +48,8 @@ export const GoogleAdSense: React.FC<GoogleAdSenseProps> = ({
     width: typeof width === "number" ? `${width}px` : width,
     height: typeof height === "number" ? `${height}px` : height,
     textAlign: inArticle ? "center" : undefined,
+    maxWidth: "100%",
+    overflow: "hidden",
     ...style,
   };
 

--- a/src/util/entry/components/ReactMarkdown.tsx
+++ b/src/util/entry/components/ReactMarkdown.tsx
@@ -94,7 +94,7 @@ export const ReactMarkdown: React.FC<ReactMarkdownProps> = ({ mdBody }) => {
             }
             if (language === "adsense") {
               return (
-                <div className="my-3">
+                <div className="my-3 w-full max-w-full overflow-hidden">
                   <GoogleAdSense
                     adClient="ca-pub-7514123900838543"
                     adSlot="8119491494"


### PR DESCRIPTION
## Summary
- Fixed AdSense ads breaking out of article container on mobile devices
- Added proper width constraints and overflow handling to GoogleAdSense component
- Updated ReactMarkdown wrapper with containment classes

## Test plan
- [x] Build completes successfully
- [x] TypeScript compilation passes
- [ ] Test on mobile viewport to verify ads stay within article bounds
- [ ] Verify ads still display correctly on desktop

🤖 Generated with [Claude Code](https://claude.ai/code)