### PR TITLE
feat: add auto monthly entry creation with GitHub Actions

### DIFF
--- a/.github/workflows/create-monthly.yml
+++ b/.github/workflows/create-monthly.yml
@@ -1,0 +1,44 @@
+name: Create Monthly Entry
+
+on:
+  schedule:
+    # 毎月1日の午前9時（JST）に実行（UTC 0時）
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+    # 手動実行も可能
+
+jobs:
+  create_monthly_entry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create monthly entry
+        run: npm run create-monthly-auto
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Commit and push changes
+        run: |
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "feat: auto-create monthly entry for $(date +'%Y-%m')"
+            git push
+          fi

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "create-entry": "node scripts/create-entry.js",
-    "create-monthly": "node scripts/create-entry.js monthly"
+    "create-monthly": "node scripts/create-entry.js monthly",
+    "create-monthly-auto": "node scripts/create-entry.js monthly-auto"
   },
   "dependencies": {
     "front-matter": "^4.0.2",

--- a/scripts/create-entry.js
+++ b/scripts/create-entry.js
@@ -105,6 +105,24 @@ function promptMonthly() {
   });
 }
 
+function createMonthlyAutomatic() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+
+  const filename = `monthly-${year}-${month.toString().padStart(2, '0')}.md`;
+  const filepath = path.join(__dirname, '..', 'src', 'entries', filename);
+
+  if (fs.existsSync(filepath)) {
+    console.error(`ファイル ${filename} は既に存在します。`);
+    process.exit(1);
+  }
+
+  const content = createMonthlyTemplate(year, month);
+  fs.writeFileSync(filepath, content, 'utf8');
+  console.log(`${filename} を作成しました。`);
+}
+
 function createRegularEntry(title) {
   if (!title) {
     console.error('タイトルを指定してください。');
@@ -128,14 +146,17 @@ function main() {
   const args = process.argv.slice(2);
 
   if (args.length === 0) {
-    console.error('使用方法: node create-entry.js [monthly] [タイトル]');
-    console.error('  monthly: 月記用テンプレートを作成');
+    console.error('使用方法: node create-entry.js [monthly] [monthly-auto] [タイトル]');
+    console.error('  monthly: 月記用テンプレートを作成（対話形式）');
+    console.error('  monthly-auto: 月記用テンプレートを作成（現在の月で自動）');
     console.error('  タイトル: 通常記事用テンプレートを作成');
     process.exit(1);
   }
 
   if (args[0] === 'monthly') {
     promptMonthly();
+  } else if (args[0] === 'monthly-auto') {
+    createMonthlyAutomatic();
   } else {
     const title = args.join(' ');
     createRegularEntry(title);


### PR DESCRIPTION
## Summary
- Add automated monthly entry creation using GitHub Actions scheduled workflow
- Create non-interactive mode for create-entry.js script
- Schedule runs on the 1st of each month at midnight UTC

## Changes
- Added `createMonthlyAutomatic()` function for non-interactive monthly entry creation
- Added `create-monthly-auto` npm script
- Created `.github/workflows/create-monthly.yml` workflow file
- Updated help text in create-entry.js

## Test plan
- [x] Verify `npm run create-monthly-auto` works locally
- [ ] Test workflow manually using workflow_dispatch
- [ ] Confirm scheduled execution works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)