### PR TITLE
月記作成Workflowがブランチを作成するように改善

### DIFF
--- a/.github/workflows/create-monthly.yml
+++ b/.github/workflows/create-monthly.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -31,7 +32,15 @@ jobs:
       - name: Create monthly entry
         run: npm run create-monthly-auto
 
-      - name: Configure Git
+      - name: Generate branch name
+        id: vars
+        run: echo "BRANCH=create-monthly-report-$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
+      - name: Create new branch
+        run: |
+          git switch -c ${{ steps.vars.outputs.BRANCH }}
+
+      - name: Configure Git Author
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -43,5 +52,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "feat: auto-create monthly entry for $(date +'%Y-%m')"
-            git push
+            git push --set-upstream origin ${{ steps.vars.outputs.BRANCH }}
           fi


### PR DESCRIPTION
## Summary
- 月記作成ワークフローが直接devブランチにプッシュしていた問題を修正
- 新しいブランチ `create-monthly-report-YYYY-MM` を作成してそこにプッシュするように変更
- ChatGPTの提案に基づいて実装

## Changes
- `fetch-depth: 0` を追加してブランチ作成を可能に
- 動的なブランチ名生成のステップを追加
- `git switch -c` でブランチを作成
- `--set-upstream` でリモートブランチにプッシュ

## Test plan
- [x] ワークフロー構文が正しいことを確認
- [x] 手動でワークフローを実行して動作確認

Fixes #507

🤖 Generated with [Claude Code](https://claude.ai/code)