### PR TITLE
fix: remove environment-dependent Claude mount from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,6 @@
     }
   },
   "mounts": [
-    "source=${localWorkspaceFolder}/.git,target=/workspaces/${localWorkspaceFolderBasename}/.git,type=bind,consistency=cached",
-    "source=${localEnv:USERPROFILE}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
+    "source=${localWorkspaceFolder}/.git,target=/workspaces/${localWorkspaceFolderBasename}/.git,type=bind,consistency=cached"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove problematic Claude configuration mount that was causing WSL devcontainer startup failures
- Keep devcontainer configuration environment-agnostic and portable across different development setups

## Test plan
- [x] Test devcontainer startup on WSL without errors
- [x] Verify git mount still works correctly
- [x] Confirm clean devcontainer.json without environment-specific paths

🤖 Generated with [Claude Code](https://claude.ai/code)