### PR TITLE
fix: correct thumbnail schema to match Zod validation

### DIFF
--- a/scripts/generate-monthly-thumbnail.js
+++ b/scripts/generate-monthly-thumbnail.js
@@ -343,12 +343,17 @@ function updateMarkdownFrontmatter(markdownPath, thumbnailPath) {
   const frontmatterContent = frontmatterBlock.slice(4, -4); // Remove --- markers
   const frontmatter = yaml.load(frontmatterContent);
 
-  // Add thumbnail and thumbnailAlt
+  // Add thumbnail as an object with url and alt
   const filename = path.basename(markdownPath);
   const { year, month } = extractYearMonth(filename);
 
-  frontmatter.thumbnail = thumbnailPath;
-  frontmatter.thumbnailAlt = `月記 (${year}年${month}月) のサマリー`;
+  // Remove /entry/ prefix since getThumbnail() in Entry.ts adds it
+  const thumbnailUrl = thumbnailPath.replace(/^\/entry\//, '');
+
+  frontmatter.thumbnail = {
+    url: thumbnailUrl,
+    alt: `月記 (${year}年${month}月) のサマリー`
+  };
 
   // Convert back to YAML
   const newFrontmatter = yaml.dump(frontmatter, {

--- a/src/entries/monthly-2025-11.md
+++ b/src/entries/monthly-2025-11.md
@@ -7,8 +7,9 @@ tags:
 summary:
   - 最初から楽しかった大喜利が、さらにどんどん楽しくなってきていて、かなり大喜利した
   - ブログ記事のネタにってくらいのWebアプリも作ってるけど出せてない
-thumbnail: /entry/monthly-report-2025-11-thumbnail.webp
-thumbnailAlt: 月記 (2025年11月) のサマリー
+thumbnail:
+  url: monthly-report-2025-11-thumbnail.webp
+  alt: 月記 (2025年11月) のサマリー
 ---
 
 ## 大喜利


### PR DESCRIPTION
## Summary
- `generate-monthly-thumbnail.js`を修正して、`thumbnail`フィールドを`url`と`alt`プロパティを持つオブジェクトとして生成するようにしました
- `monthly-2025-11.md`のフロントマターを正しいスキーマに修正しました
- サムネイルURLから`/entry/`プレフィックスを削除（`getThumbnail()`メソッドで自動追加されるため）

## Problem
ビルド時に以下のZodバリデーションエラーが発生していました:
```
Error [ZodError]: Expected object, received string for "thumbnail" field
```

## Solution
`Entry.ts`のZodスキーマでは、`thumbnail`は以下の形式を期待しています:
```typescript
thumbnail: {
  url: string,
  alt: string
}
```

しかし、`generate-monthly-thumbnail.js`では以下のように文字列として設定していました:
```javascript
frontmatter.thumbnail = thumbnailPath;
frontmatter.thumbnailAlt = `月記 (${year}年${month}月) のサマリー`;
```

これを修正して、正しいオブジェクト形式で設定するようにしました。

## Test plan
- [x] `npm run build`が正常に完了することを確認
- [x] `generate-monthly-thumbnail.js`を実行して、正しいフォーマットが生成されることを確認
- [x] 既存の月記エントリ(monthly-2025-11.md)が正しく修正されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)