### PR TITLE
fix: enable hot reload for markdown file changes in development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,6 @@
+const path = require("path");
+const fs = require("fs");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
@@ -6,6 +9,41 @@ const nextConfig = {
     unoptimized: true,
   },
   trailingSlash: true,
+  webpack: (config, { dev, webpack }) => {
+    if (dev) {
+      // Create a custom plugin to watch markdown files
+      class WatchMarkdownPlugin {
+        apply(compiler) {
+          compiler.hooks.afterCompile.tap(
+            "WatchMarkdownPlugin",
+            (compilation) => {
+              const entriesDir = path.join(process.cwd(), "src/entries");
+              const worksDir = path.join(process.cwd(), "src/works");
+
+              // Add markdown files as file dependencies
+              const addMarkdownFiles = (dir) => {
+                if (fs.existsSync(dir)) {
+                  const files = fs.readdirSync(dir);
+                  files.forEach((file) => {
+                    if (file.endsWith(".md")) {
+                      const filePath = path.join(dir, file);
+                      compilation.fileDependencies.add(filePath);
+                    }
+                  });
+                }
+              };
+
+              addMarkdownFiles(entriesDir);
+              addMarkdownFiles(worksDir);
+            },
+          );
+        }
+      }
+
+      config.plugins.push(new WatchMarkdownPlugin());
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/src/util/work/Work.ts
+++ b/src/util/work/Work.ts
@@ -65,6 +65,10 @@ class Work {
 export class WorkManager {
   public static instance: WorkManager | null = null;
   public static getInstance() {
+    if (process.env.NODE_ENV === "development") {
+      return new WorkManager();
+    }
+
     if (WorkManager.instance) {
       return WorkManager.instance;
     } else {


### PR DESCRIPTION
## Summary

Fixes markdown hot reload issue in development mode where changes to `.md` files weren't reflected in the browser without restarting the server.

## Changes

1. **Added webpack plugin to watch markdown files**
   - Created custom `WatchMarkdownPlugin` in `next.config.js`
   - Plugin adds all markdown files in `src/entries/` and `src/works/` as file dependencies
   - Webpack now watches these files and triggers recompilation on changes

2. **Updated WorkManager to recreate instances in development**
   - Modified `WorkManager.getInstance()` to match `EntryManager`'s behavior
   - In development mode, returns new instance instead of singleton
   - Ensures markdown content is re-read on each request during development

## Testing

- ✅ Build passes successfully
- ✅ Code formatted with Prettier
- The fix ensures that when markdown files are modified during `npm run dev`, the changes will trigger hot reload and update in the browser

## Technical Details

The root cause was that Next.js wasn't watching markdown files because they're loaded via `fs.readFileSync()` rather than being imported. The webpack plugin adds these files as compilation dependencies, which tells webpack to watch them for changes and trigger hot module replacement when they're modified.

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)