### PR TITLE
chore: exclude markdown files from prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Markdown files
+*.md
+
+# Build output
+out/
+.next/
+
+# Dependencies
+node_modules/


### PR DESCRIPTION
## Summary

Added `.prettierignore` to exclude markdown files from prettier formatting.

## Motivation

Markdown files contain content that should preserve its original formatting. Prettier's markdown formatting can sometimes modify the content in unintended ways, especially for blog entries and documentation.

## Changes

Created `.prettierignore` with the following exclusions:
- `*.md` - All markdown files
- `out/`, `.next/` - Build output directories
- `node_modules/` - Dependencies

## Impact

- Running `npm run format` will no longer modify markdown files
- Other file types (TypeScript, JavaScript, JSON, etc.) will continue to be formatted as before
- Improves developer experience by preserving intentional markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)